### PR TITLE
Updating Tomcat to the latest versions prior to 1.0.0-Final

### DIFF
--- a/tomcat-embedded-6/pom.xml
+++ b/tomcat-embedded-6/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
 
-        <version.org.apache.tomcat>6.0.29</version.org.apache.tomcat>
+        <version.org.apache.tomcat>6.0.32</version.org.apache.tomcat>
 
     </properties>
 

--- a/tomcat-embedded-7/pom.xml
+++ b/tomcat-embedded-7/pom.xml
@@ -17,7 +17,7 @@
 
    <properties>
 
-      <version.org.apache.tomcat>7.0.16</version.org.apache.tomcat>
+      <version.org.apache.tomcat>7.0.19</version.org.apache.tomcat>
 
    </properties>
 


### PR DESCRIPTION
Updating Tomcat to the latest versions prior to the Arquillian 1.0.0-Final release.  Tomcat 6.0.32 listed ECJ 3.3.1 as a dependency, but that ECJ version was missing from Central.  I bundled and submitted it.  It's been accepted and synced: http://search.maven.org/#artifactdetails%7Corg.eclipse.jdt.core.compiler%7Cecj%7C3.3.1%7Cjar.
