### PR TITLE
Antrun plugin must use <tasks> instead of <target> because the latter is 

### DIFF
--- a/tomcat-managed-6/pom.xml
+++ b/tomcat-managed-6/pom.xml
@@ -94,14 +94,14 @@
                     <execution>
                         <phase>generate-test-resources</phase>
                         <configuration>
-                            <target>
+                            <tasks>
                                 <mkdir dir="${project.build.directory}/downloads" />
                                 <get
                                     src="http://archive.apache.org/dist/tomcat/tomcat-6/v${version.org.apache.tomcat}/bin/apache-tomcat-${version.org.apache.tomcat}.zip"
                                     dest="${project.build.directory}/downloads" verbose="true" skipexisting="true" />
                                 <unzip src="${project.build.directory}/downloads/apache-tomcat-${version.org.apache.tomcat}.zip"
                                     dest="${project.build.directory}" />
-                            </target>
+                            </tasks>
                         </configuration>
                         <goals>
                             <goal>run</goal>


### PR DESCRIPTION
Antrun plugin must use <tasks> instead of <target> because the latter is silently ignored if you configure multiple antrun executions (or plugins).
