### PR TITLE
JVM arguments parsing fixed

### DIFF
--- a/tomcat-managed-5.5/src/main/java/org/jboss/arquillian/container/tomcat/managed_5_5/TomcatManagedContainer.java
+++ b/tomcat-managed-5.5/src/main/java/org/jboss/arquillian/container/tomcat/managed_5_5/TomcatManagedContainer.java
@@ -101,12 +101,13 @@ public class TomcatManagedContainer implements DeployableContainer<TomcatManaged
          cmd.add("-Dcom.sun.management.jmxremote.ssl=false");
          cmd.add("-Dcom.sun.management.jmxremote.authenticate=false");
 
-         if (ADDITIONAL_JAVA_OPTS != null)
-         {
-            for (String opt : ADDITIONAL_JAVA_OPTS.split(" "))
-            {
-               cmd.add(opt);
-            }
+         if (ADDITIONAL_JAVA_OPTS != null) {
+        	  for (String opt : ADDITIONAL_JAVA_OPTS.split(" ")) {
+
+        	    if ( !(opt.trim()).isEmpty() ) {
+        		  cmd.add(opt);
+        	    }
+        	  }
          }
 
          String absolutePath = new File(CATALINA_HOME).getAbsolutePath();

--- a/tomcat-managed-6/src/main/java/org/jboss/arquillian/container/tomcat/managed_6/TomcatManagedContainer.java
+++ b/tomcat-managed-6/src/main/java/org/jboss/arquillian/container/tomcat/managed_6/TomcatManagedContainer.java
@@ -109,9 +109,12 @@ public class TomcatManagedContainer implements DeployableContainer<TomcatManaged
             cmd.add("-Dcom.sun.management.jmxremote.authenticate=false");
 
             if (ADDITIONAL_JAVA_OPTS != null) {
-                for (String opt : ADDITIONAL_JAVA_OPTS.split(" ")) {
-                    cmd.add(opt);
-                }
+            	  for (String opt : ADDITIONAL_JAVA_OPTS.split(" ")) {
+
+            	    if ( !(opt.trim()).isEmpty() ) {
+            		  cmd.add(opt);
+            	    }
+            	  }
             }
 
             String absolutePath = new File(CATALINA_HOME).getAbsolutePath();

--- a/tomcat-managed-7/src/main/java/org/jboss/arquillian/container/tomcat/managed_7/TomcatManagedContainer.java
+++ b/tomcat-managed-7/src/main/java/org/jboss/arquillian/container/tomcat/managed_7/TomcatManagedContainer.java
@@ -107,9 +107,12 @@ public class TomcatManagedContainer implements DeployableContainer<TomcatManaged
             cmd.add("-Dcom.sun.management.jmxremote.authenticate=false");
 
             if (ADDITIONAL_JAVA_OPTS != null) {
-                for (String opt : ADDITIONAL_JAVA_OPTS.split(" ")) {
-                    cmd.add(opt);
-                }
+            	  for (String opt : ADDITIONAL_JAVA_OPTS.split(" ")) {
+
+            	    if ( !(opt.trim()).isEmpty() ) {
+            		  cmd.add(opt);
+            	    }
+            	  }
             }
 
             String absolutePath = new File(CATALINA_HOME).getAbsolutePath();


### PR DESCRIPTION
When JVM arguments were on multiple lines then caused exception during starting of Tomcat. Now it does not.
