### PR TITLE
Tomcat should be launched with java from current VM

### DIFF
--- a/tomcat-managed-5.5/src/main/java/org/jboss/arquillian/container/tomcat/managed_5_5/TomcatManagedContainer.java
+++ b/tomcat-managed-5.5/src/main/java/org/jboss/arquillian/container/tomcat/managed_5_5/TomcatManagedContainer.java
@@ -53,6 +53,8 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptor;
 public class TomcatManagedContainer implements DeployableContainer<TomcatManagedConfiguration>
 {
    private static final Logger log = Logger.getLogger(TomcatManagedContainer.class.getName());
+   private static final String JAVA_FROM_CURRENT_VM = 
+      System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
 
    /**
     * Tomcat container configuration
@@ -96,7 +98,7 @@ public class TomcatManagedContainer implements DeployableContainer<TomcatManaged
          // construct a command to execute
          List<String> cmd = new ArrayList<String>();
 
-         cmd.add("java");
+         cmd.add(JAVA_FROM_CURRENT_VM);
 
          cmd.add("-Dcom.sun.management.jmxremote.port=" + configuration.getJmxPort());
          cmd.add("-Dcom.sun.management.jmxremote.ssl=false");

--- a/tomcat-managed-6/src/main/java/org/jboss/arquillian/container/tomcat/managed_6/TomcatManagedContainer.java
+++ b/tomcat-managed-6/src/main/java/org/jboss/arquillian/container/tomcat/managed_6/TomcatManagedContainer.java
@@ -53,6 +53,8 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptor;
  */
 public class TomcatManagedContainer implements DeployableContainer<TomcatManagedConfiguration> {
     private static final Logger log = Logger.getLogger(TomcatManagedContainer.class.getName());
+    private static final String JAVA_FROM_CURRENT_VM = 
+        System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
 
     /**
      * Tomcat container configuration
@@ -103,7 +105,7 @@ public class TomcatManagedContainer implements DeployableContainer<TomcatManaged
             // construct a command to execute
             List<String> cmd = new ArrayList<String>();
 
-            cmd.add("java");
+            cmd.add(JAVA_FROM_CURRENT_VM);
 
             cmd.add("-Dcom.sun.management.jmxremote.port=" + configuration.getJmxPort());
             cmd.add("-Dcom.sun.management.jmxremote.ssl=false");

--- a/tomcat-managed-7/src/main/java/org/jboss/arquillian/container/tomcat/managed_7/TomcatManagedContainer.java
+++ b/tomcat-managed-7/src/main/java/org/jboss/arquillian/container/tomcat/managed_7/TomcatManagedContainer.java
@@ -51,6 +51,8 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptor;
  */
 public class TomcatManagedContainer implements DeployableContainer<TomcatManagedConfiguration> {
     private static final Logger log = Logger.getLogger(TomcatManagedContainer.class.getName());
+    private static final String JAVA_FROM_CURRENT_VM = 
+        System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
 
     /**
      * Tomcat container configuration
@@ -101,7 +103,7 @@ public class TomcatManagedContainer implements DeployableContainer<TomcatManaged
             // construct a command to execute
             List<String> cmd = new ArrayList<String>();
 
-            cmd.add("java");
+            cmd.add(JAVA_FROM_CURRENT_VM);
 
             cmd.add("-Dcom.sun.management.jmxremote.port=" + configuration.getJmxPort());
             cmd.add("-Dcom.sun.management.jmxremote.ssl=false");


### PR DESCRIPTION
As tests may be executed on a specified Java version
ex.: _JAVA_HOME=... mvn clean install_

Tomcat should be launched with the same Java version, in order to be consistent.
