### PR TITLE
ARQ-2033 Fixed the Tomcat launch command line generation to use the local file…

### DIFF
--- a/tomcat-common/src/main/java/org/jboss/arquillian/container/tomcat/TomcatManager.java
+++ b/tomcat-common/src/main/java/org/jboss/arquillian/container/tomcat/TomcatManager.java
@@ -41,7 +41,6 @@ import org.jboss.arquillian.container.spi.client.container.DeploymentException;
  *
  * @author <a href="mailto:kpiwko@redhat.com">Karel Piwko</a>
  * @author Craig R. McClanahan
- *
  */
 public class TomcatManager<C extends TomcatConfiguration> {
 
@@ -135,16 +134,16 @@ public class TomcatManager<C extends TomcatConfiguration> {
      * Execute the specified command, based on the configured properties. The input stream will be closed upon completion of
      * this task, whether it was executed successfully or not.
      *
-     * @param command Command to be executed
-     * @param istream InputStream to include in an HTTP PUT, if any
-     * @param contentType Content type to specify for the input, if any
+     * @param command       Command to be executed
+     * @param istream       InputStream to include in an HTTP PUT, if any
+     * @param contentType   Content type to specify for the input, if any
      * @param contentLength Content length to specify for the input, if any
      * @throws IOException
      * @throws MalformedURLException
      * @throws DeploymentException
      */
     protected void execute(final String command, final InputStream istream, final String contentType, final int contentLength)
-        throws IOException {
+            throws IOException {
 
         URLConnection conn = null;
         try {
@@ -202,20 +201,20 @@ public class TomcatManager<C extends TomcatConfiguration> {
         // Supposes that <= 199 is not bad, but is it? See http://en.wikipedia.org/wiki/List_of_HTTP_status_codes
         if (httpResponseCode >= 400 && httpResponseCode < 500) {
             throw new ConfigurationException(
-                "Unable to connect to Tomcat manager. "
-                    + "The server command ("
-                    + command
-                    + ") failed with responseCode ("
-                    + httpResponseCode
-                    + ") and responseMessage ("
-                    + hconn.getResponseMessage()
-                    + ").\n\n"
-                    + "Please make sure that you provided correct credentials to an user which is able to access Tomcat manager application.\n"
-                    + "These credentials can be specified in the Arquillian container configuration as \"user\" and \"pass\" properties.\n"
-                    + "The user must have aapropriate role specified in tomcat-users.xml file.\n");
+                    "Unable to connect to Tomcat manager. "
+                            + "The server command ("
+                            + command
+                            + ") failed with responseCode ("
+                            + httpResponseCode
+                            + ") and responseMessage ("
+                            + hconn.getResponseMessage()
+                            + ").\n\n"
+                            + "Please make sure that you provided correct credentials to an user which is able to access Tomcat manager application.\n"
+                            + "These credentials can be specified in the Arquillian container configuration as \"user\" and \"pass\" properties.\n"
+                            + "The user must have aapropriate role specified in tomcat-users.xml file.\n");
         } else if (httpResponseCode >= 300) {
             throw new IllegalStateException("The server command (" + command + ") failed with responseCode ("
-                + httpResponseCode + ") and responseMessage (" + hconn.getResponseMessage() + ").");
+                    + httpResponseCode + ") and responseMessage (" + hconn.getResponseMessage() + ").");
         }
         BufferedReader reader = null;
         try {

--- a/tomcat-managed-common/src/main/java/org/jboss/arquillian/container/tomcat/managed/TomcatManagedContainer.java
+++ b/tomcat-managed-common/src/main/java/org/jboss/arquillian/container/tomcat/managed/TomcatManagedContainer.java
@@ -124,8 +124,9 @@ abstract class TomcatManagedContainer implements DeployableContainer<TomcatManag
             final List<String> cmd = new ArrayList<String>();
 
             cmd.add(javaCommand);
+            String seperator=File.separator;
 
-            cmd.add("-Djava.util.logging.config.file=" + absoluteCatalinaBasePath + "/conf/"
+            cmd.add("-Djava.util.logging.config.file=" + absoluteCatalinaBasePath +seperator+ "conf"+seperator
                 + configuration.getLoggingProperties());
             cmd.add("-Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager");
 
@@ -135,18 +136,18 @@ abstract class TomcatManagedContainer implements DeployableContainer<TomcatManag
 
             cmd.addAll(AdditionalJavaOptionsParser.parse(ADDITIONAL_JAVA_OPTS));
 
-            String CLASS_PATH = absoluteCatalinaHomePath + "/bin/bootstrap.jar" + System.getProperty("path.separator");
-            CLASS_PATH += absoluteCatalinaHomePath + "/bin/tomcat-juli.jar";
+            String CLASS_PATH = absoluteCatalinaHomePath + seperator+ "bin"+seperator+"bootstrap.jar" +File.pathSeparator;
+            CLASS_PATH += absoluteCatalinaHomePath + seperator+"bin"+seperator+"tomcat-juli.jar";
 
             cmd.add("-classpath");
             cmd.add(CLASS_PATH);
-            cmd.add("-Djava.endorsed.dirs=" + absoluteCatalinaHomePath + "/endorsed");
+            cmd.add("-Djava.endorsed.dirs=" + absoluteCatalinaHomePath +seperator+ "endorsed");
             cmd.add("-Dcatalina.base=" + absoluteCatalinaBasePath);
             cmd.add("-Dcatalina.home=" + absoluteCatalinaHomePath);
-            cmd.add("-Djava.io.tmpdir=" + absoluteCatalinaBasePath + "/temp");
+            cmd.add("-Djava.io.tmpdir=" + absoluteCatalinaBasePath + seperator+ "temp");
             cmd.add("org.apache.catalina.startup.Bootstrap");
             cmd.add("-config");
-            cmd.add(absoluteCatalinaBasePath + "/conf/" + configuration.getServerConfig());
+            cmd.add(absoluteCatalinaBasePath + seperator+"conf"+seperator + configuration.getServerConfig());
             cmd.add("start");
 
             // execute command


### PR DESCRIPTION
… system path convention instead of hard coded '/' characters in string fragments.

This allows for Managed Tomcat testing for developers afflicted by Windows
