### PR TITLE
Changes to make the project up-to-date

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,11 +28,11 @@
 
     <properties>
 
-        <arquillian.core.version>1.1.5.Final</arquillian.core.version>
-        <shrinkwrap.version>1.2.2</shrinkwrap.version>
-        <shrinkwrap.descriptors.version>2.0.0-alpha-5</shrinkwrap.descriptors.version>
-        <shrinkwrap.resolver.version>2.1.1</shrinkwrap.resolver.version>
-        <weld.version>1.1.8.Final</weld.version>
+        <arquillian.core.version>1.1.11.Final</arquillian.core.version>
+        <shrinkwrap.version>1.2.6</shrinkwrap.version>
+        <shrinkwrap.descriptors.version>2.0.0-alpha-10</shrinkwrap.descriptors.version>
+        <shrinkwrap.resolver.version>2.2.4</shrinkwrap.resolver.version>
+        <weld.version>1.1.33.Final</weld.version>
 
         <!-- override from parent -->
         <maven.compiler.argument.target>1.5</maven.compiler.argument.target>
@@ -47,21 +47,6 @@
         <dependencies>
 
             <!-- BOMs -->
-
-            <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-bom</artifactId>
-                <version>${arquillian.core.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-build</artifactId>
-                <version>${arquillian.core.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>org.jboss.shrinkwrap</groupId>
                 <artifactId>shrinkwrap-bom</artifactId>
@@ -83,26 +68,19 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
-            <!-- Depchains -->
-
             <dependency>
-                <groupId>org.jboss.shrinkwrap</groupId>
-                <artifactId>shrinkwrap-depchain</artifactId>
-                <version>${shrinkwrap.version}</version>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${arquillian.core.version}</version>
                 <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.jboss.shrinkwrap.descriptors</groupId>
-                <artifactId>shrinkwrap-descriptors-depchain</artifactId>
-                <version>${shrinkwrap.descriptors.version}</version>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-build</artifactId>
+                <version>${arquillian.core.version}</version>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.shrinkwrap.resolver</groupId>
-                <artifactId>shrinkwrap-resolver-depchain</artifactId>
-                <version>${shrinkwrap.resolver.version}</version>
-                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <!-- Test Scope -->

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>14</version>
+        <version>21</version>
         <relativePath />
     </parent>
 
@@ -35,12 +35,11 @@
         <weld.version>1.1.33.Final</weld.version>
 
         <!-- override from parent -->
-        <maven.compiler.argument.target>1.5</maven.compiler.argument.target>
-        <maven.compiler.argument.source>1.5</maven.compiler.argument.source>
+        <maven.compiler.target>1.5</maven.compiler.target>
+        <maven.compiler.source>1.5</maven.compiler.source>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
     </properties>
 
     <dependencyManagement>

--- a/tomcat-embedded-6/pom.xml
+++ b/tomcat-embedded-6/pom.xml
@@ -15,7 +15,7 @@
     <name>Arquillian Tomcat Embedded 6.x Container</name>
 
     <properties>
-        <tomcat.version>6.0.32</tomcat.version>
+        <tomcat.version>6.0.47</tomcat.version>
         <shrinkwrap.container.tomcat.version>1.0.0-beta-1</shrinkwrap.container.tomcat.version>
     </properties>
 

--- a/tomcat-embedded-7/pom.xml
+++ b/tomcat-embedded-7/pom.xml
@@ -15,8 +15,8 @@
     <name>Arquillian Tomcat Embedded 7.x Container</name>
 
     <properties>
-        <tomcat.version>7.0.52</tomcat.version>
-        <ecj.version>3.7</ecj.version>
+        <tomcat.version>7.0.72</tomcat.version>
+        <ecj.version>4.6.1</ecj.version>
     </properties>
 
     <dependencies>

--- a/tomcat-embedded-8/pom.xml
+++ b/tomcat-embedded-8/pom.xml
@@ -15,7 +15,7 @@
     <name>Arquillian Tomcat Embedded 8.x Container</name>
 
     <properties>
-        <tomcat.version>8.0.1</tomcat.version>
+        <tomcat.version>8.0.38</tomcat.version>
         <ecj.version>4.3.1</ecj.version>
     </properties>
 

--- a/tomcat-managed-5.5/pom.xml
+++ b/tomcat-managed-5.5/pom.xml
@@ -17,7 +17,7 @@
     <properties>
 
         <tomcat.major.version>5</tomcat.major.version>
-        <tomcat.version>${tomcat.major.version}.5.33</tomcat.version>
+        <tomcat.version>${tomcat.major.version}.5.36</tomcat.version>
 
         <test.catalina.home>${project.build.directory}/cargo/installs/apache-tomcat-${tomcat.version}/apache-tomcat-${tomcat.version}</test.catalina.home>
         <test.catalina.base>${project.build.directory}/cargo/configurations/tomcat${tomcat.major.version}x</test.catalina.base>

--- a/tomcat-managed-5.5/pom.xml
+++ b/tomcat-managed-5.5/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,9 +19,7 @@
         <tomcat.major.version>5</tomcat.major.version>
         <tomcat.version>${tomcat.major.version}.5.36</tomcat.version>
 
-        <test.catalina.home>${project.build.directory}/cargo/installs/apache-tomcat-${tomcat.version}/apache-tomcat-${tomcat.version}</test.catalina.home>
-        <test.catalina.base>${project.build.directory}/cargo/configurations/tomcat${tomcat.major.version}x</test.catalina.base>
-
+        <skipTests>true</skipTests>
     </properties>
 
     <dependencies>
@@ -33,7 +31,7 @@
             <scope>test</scope>
         </dependency>
 
-      <!-- Tomcat 5.5 specific tests, Weld is not compatible, testing @Resource injection -->
+        <!-- Tomcat 5.5 specific tests, Weld is not compatible, testing @Resource injection -->
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>jsr250-api</artifactId>
@@ -43,25 +41,45 @@
 
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.cargo</groupId>
-                <artifactId>cargo-maven2-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>install-container</id>
+
+    <profiles>
+        <profile>
+            <id>JDK5-7</id>
+            <activation>
+                <jdk>[1.5,1.7]</jdk>
+            </activation>
+            <properties>
+                <skipTests>false</skipTests>
+                <test.catalina.home>${project.build.directory}/cargo/installs/apache-tomcat-${tomcat.version}/apache-tomcat-${tomcat.version}</test.catalina.home>
+                <test.catalina.base>${project.build.directory}/cargo/configurations/tomcat${tomcat.major.version}x</test.catalina.base>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <container>
-                                <containerId>tomcat${tomcat.major.version}x</containerId>
-                                <zipUrlInstaller>
-                                    <url>http://archive.apache.org/dist/tomcat/tomcat-${tomcat.major.version}/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
-                                </zipUrlInstaller>
-                            </container>
+                            <skipTests>false</skipTests>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.cargo</groupId>
+                        <artifactId>cargo-maven2-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>install-container</id>
+                                <configuration>
+                                    <container>
+                                        <containerId>tomcat${tomcat.major.version}x</containerId>
+                                        <zipUrlInstaller>
+                                            <url>http://archive.apache.org/dist/tomcat/tomcat-${tomcat.major.version}/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
+                                        </zipUrlInstaller>
+                                    </container>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/tomcat-managed-6/pom.xml
+++ b/tomcat-managed-6/pom.xml
@@ -17,7 +17,7 @@
     <properties>
 
         <tomcat.major.version>6</tomcat.major.version>
-        <tomcat.version>${tomcat.major.version}.0.32</tomcat.version>
+        <tomcat.version>${tomcat.major.version}.0.47</tomcat.version>
 
         <test.catalina.home>${project.build.directory}/cargo/installs/apache-tomcat-${tomcat.version}/apache-tomcat-${tomcat.version}</test.catalina.home>
         <test.catalina.base>${project.build.directory}/cargo/configurations/tomcat${tomcat.major.version}x</test.catalina.base>

--- a/tomcat-managed-7/pom.xml
+++ b/tomcat-managed-7/pom.xml
@@ -17,7 +17,7 @@
     <properties>
 
         <tomcat.major.version>7</tomcat.major.version>
-        <tomcat.version>${tomcat.major.version}.0.20</tomcat.version>
+        <tomcat.version>${tomcat.major.version}.0.72</tomcat.version>
 
         <test.catalina.home>${project.build.directory}/cargo/installs/apache-tomcat-${tomcat.version}/apache-tomcat-${tomcat.version}</test.catalina.home>
         <test.catalina.base>${project.build.directory}/cargo/configurations/tomcat${tomcat.major.version}x</test.catalina.base>

--- a/tomcat-remote-6/pom.xml
+++ b/tomcat-remote-6/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <tomcat.major.version>6</tomcat.major.version>
-        <tomcat.version>${tomcat.major.version}.0.32</tomcat.version>
+        <tomcat.version>${tomcat.major.version}.0.47</tomcat.version>
     </properties>
 
     <dependencies>

--- a/tomcat-remote-7/pom.xml
+++ b/tomcat-remote-7/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <tomcat.major.version>7</tomcat.major.version>
-        <tomcat.version>${tomcat.major.version}.0.20</tomcat.version>
+        <tomcat.version>${tomcat.major.version}.0.72</tomcat.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
ARQ-2055 Upgraded Tomcat containers to the latest versions

ARQ-2056 Tests in tomcat-managed-5.5 module are skipped when JDK 1.8 is used

ARQ-2057 Upgraded Arquillian,ShinkWrap and Weld to the latest versions, fixed order of BOMs, removed unnecessary depchains from dependency-management