### PR TITLE
ARQ-2071 Use more safe serverifo command to check if container runs

### DIFF
--- a/tomcat-common/src/main/java/org/jboss/arquillian/container/tomcat/Tomcat55ManagerCommandSpec.java
+++ b/tomcat-common/src/main/java/org/jboss/arquillian/container/tomcat/Tomcat55ManagerCommandSpec.java
@@ -26,6 +26,10 @@ package org.jboss.arquillian.container.tomcat;
  */
 public class Tomcat55ManagerCommandSpec implements TomcatManagerCommandSpec {
 
+	public String getServerInfoCommand() {
+		return "/serverinfo";
+	}
+	
     public String getListCommand() {
 
         return "/list";

--- a/tomcat-common/src/main/java/org/jboss/arquillian/container/tomcat/Tomcat7ManagerCommandSpec.java
+++ b/tomcat-common/src/main/java/org/jboss/arquillian/container/tomcat/Tomcat7ManagerCommandSpec.java
@@ -26,6 +26,10 @@ package org.jboss.arquillian.container.tomcat;
  */
 public class Tomcat7ManagerCommandSpec implements TomcatManagerCommandSpec {
 
+	public String getServerInfoCommand() {
+		return "/text/serverinfo";
+	}
+	
     public String getListCommand() {
 
         return "/text/list";

--- a/tomcat-common/src/main/java/org/jboss/arquillian/container/tomcat/TomcatManager.java
+++ b/tomcat-common/src/main/java/org/jboss/arquillian/container/tomcat/TomcatManager.java
@@ -100,6 +100,10 @@ public class TomcatManager<C extends TomcatConfiguration> {
         execute(command.toString(), null, null, -1);
     }
 
+    public void serverInfo() throws IOException {
+        execute(tomcatManagerCommandSpec.getServerInfoCommand(), null, null, -1);
+    }
+    
     public void list() throws IOException {
 
         execute(tomcatManagerCommandSpec.getListCommand(), null, null, -1);
@@ -108,7 +112,7 @@ public class TomcatManager<C extends TomcatConfiguration> {
     public boolean isRunning() {
 
         try {
-            list();
+            serverInfo();
             return true;
         } catch (final IOException e) {
             return false;

--- a/tomcat-common/src/main/java/org/jboss/arquillian/container/tomcat/TomcatManager.java
+++ b/tomcat-common/src/main/java/org/jboss/arquillian/container/tomcat/TomcatManager.java
@@ -104,6 +104,11 @@ public class TomcatManager<C extends TomcatConfiguration> {
         execute(tomcatManagerCommandSpec.getServerInfoCommand(), null, null, -1);
     }
     
+    /**
+     * This method is deprecated, please use {@link TomcatManager#serverInfo()} instead, to find out if container is running. 
+     * 
+     */
+    @Deprecated
     public void list() throws IOException {
 
         execute(tomcatManagerCommandSpec.getListCommand(), null, null, -1);

--- a/tomcat-common/src/main/java/org/jboss/arquillian/container/tomcat/TomcatManagerCommandSpec.java
+++ b/tomcat-common/src/main/java/org/jboss/arquillian/container/tomcat/TomcatManagerCommandSpec.java
@@ -24,9 +24,16 @@ package org.jboss.arquillian.container.tomcat;
 public interface TomcatManagerCommandSpec {
 
     /**
+     * The server info command.
+     *
+     * @return the server info command.
+     */
+    String getServerInfoCommand();
+	
+    /**
      * The list command.
      *
-     * @return the deploy command.
+     * @return the list command.
      */
     String getListCommand();
 


### PR DESCRIPTION
#### Short description of what this resolves:
Use more safe `serverifo` command to check if container runs

#### Changes proposed in this pull request:

- Switches command for checking if container runs from `list` to `serverinfo` as not all session managers implements `list` command (typically for security reasons)


**Fixes**: https://issues.jboss.org/browse/ARQ-2071
