### PR TITLE
ARQ-2194 Tomcat 9 embedded starts without connector by default, we ne…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.7</version>
+        <version>1.17</version>
         <executions>
           <execution>
             <id>signature-check</id>

--- a/tomcat-embedded-8/src/main/java/org/jboss/arquillian/container/tomcat/embedded/Tomcat8EmbeddedContainer.java
+++ b/tomcat-embedded-8/src/main/java/org/jboss/arquillian/container/tomcat/embedded/Tomcat8EmbeddedContainer.java
@@ -211,6 +211,7 @@ public class Tomcat8EmbeddedContainer implements DeployableContainer<TomcatEmbed
         tomcat.setHostname(hostname);
         tomcat.setPort(configuration.getBindHttpPort());
         tomcat.setBaseDir(tempDir.getAbsolutePath());
+        tomcat.getConnector();
 
         // Enable JNDI - it is disabled by default.
         tomcat.enableNaming();

--- a/tomcat-embedded-9/pom.xml
+++ b/tomcat-embedded-9/pom.xml
@@ -11,15 +11,21 @@
         <relativePath>../tomcat-embedded-parent/pom.xml</relativePath>
     </parent>
 
-    <artifactId>arquillian-tomcat-embedded-8</artifactId>
-    <name>Arquillian Tomcat Embedded 8.x Container</name>
+    <artifactId>arquillian-tomcat-embedded-9</artifactId>
+    <name>Arquillian Tomcat Embedded 9.x Container</name>
 
     <properties>
-        <tomcat.version>8.0.39</tomcat.version>
+        <tomcat.version>9.0.11</tomcat.version>
         <ecj.version>4.6.1</ecj.version>
     </properties>
 
     <dependencies>
+        <!--Depend on version 8 as it is exactly the same-->
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-tomcat-embedded-8</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
@@ -32,17 +38,17 @@
             <version>${tomcat.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.jdt.core.compiler</groupId>
-            <artifactId>ecj</artifactId>
-            <version>${ecj.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-logging-juli</artifactId>
-            <version>${tomcat.version}</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
+
+    <build>
+        <!--Use sources and tests sources from embedded 8-->
+        <testResources>
+            <testResource>
+                <directory>../tomcat-embedded-8/src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+        <sourceDirectory>../tomcat-embedded-8/src/main</sourceDirectory>
+        <testSourceDirectory>../tomcat-embedded-8/src/test</testSourceDirectory>
+    </build>
 </project>


### PR DESCRIPTION
…ister one ourselves.

JIRA link - https://issues.jboss.org/browse/ARQ-2194

I was trying to utilize tomcat-embedded-8 adapter with Tomcat 9 (in[ Weld servlet testing](https://github.com/weld/core/tree/master/environments/servlet/tests/tomcat))
Turns out there is one change needed during startup, Tomcat 9 by default does not register any connectors (e.g. listens on no ports). Adding this line fixes it for Tomcat 9 and it still works with Tomcat 8.

Happy to provide any additional details/info/changes.