### PR TITLE
Allow automatic port selection by tomcat

### DIFF
--- a/tomcat-embedded-8/src/main/java/org/jboss/arquillian/container/tomcat/embedded/EmbeddedContextConfig.java
+++ b/tomcat-embedded-8/src/main/java/org/jboss/arquillian/container/tomcat/embedded/EmbeddedContextConfig.java
@@ -68,8 +68,6 @@ public class EmbeddedContextConfig extends ContextConfig {
         Tomcat.initWebappDefaults(context);
     }
 
-    ;
-
     /**
      * Override to assign an internal field that will trigger the removal of the unpacked WAR when the context is closed.
      */

--- a/tomcat-embedded-8/src/main/java/org/jboss/arquillian/container/tomcat/embedded/Tomcat8EmbeddedContainer.java
+++ b/tomcat-embedded-8/src/main/java/org/jboss/arquillian/container/tomcat/embedded/Tomcat8EmbeddedContainer.java
@@ -150,8 +150,8 @@ public class Tomcat8EmbeddedContainer implements DeployableContainer<TomcatEmbed
             final StandardContext standardContext = (StandardContext) host.findChild(contextName.getName());
             standardContextProducer.set(standardContext);
 
-            final HTTPContext httpContext =
-                new HTTPContext(configuration.getBindAddress(), configuration.getBindHttpPort());
+            // CHANGED: Use tomcat values instead of configured once, to support automatic port selection
+            final HTTPContext httpContext = new HTTPContext(tomcat.getHost().getName(), tomcat.getConnector().getLocalPort());
 
             for (final String mapping : standardContext.findServletMappings()) {
                 httpContext.add(new Servlet(standardContext.findServletMapping(mapping), contextName.getPath()));
@@ -230,8 +230,11 @@ public class Tomcat8EmbeddedContainer implements DeployableContainer<TomcatEmbed
         host.setAutoDeploy(false);
         host.setConfigClass(EmbeddedContextConfig.class.getCanonicalName());
 
+        // CHANGED: call embeddedHostConfig.setUnpackWARs again instead of ((StandardHost) host).setUnpackWARs(configuration.isUnpackArchive()), without this change org.apache.wicket.protocol.http.WebApplication.getServletContext().getRealPath("/") return null
+        // with embeddedHostConfig.setUnpackWARs(configuration.isUnpackArchive()); it returns the valid path somewhere in [userdir]]\AppData\Local\Temp\ so i expect ((StandardHost) host).setUnpackWARs(configuration.isUnpackArchive()) is not working propably in an
+        // arquillian tomcat8 setup
         embeddedHostConfig = new EmbeddedHostConfig();
-        ((StandardHost) host).setUnpackWARs(configuration.isUnpackArchive());
+        embeddedHostConfig.setUnpackWARs(configuration.isUnpackArchive());
 
         host.addLifecycleListener(embeddedHostConfig);
 

--- a/tomcat-embedded-common/src/main/java/org/jboss/arquillian/container/tomcat/embedded/TomcatEmbeddedConfiguration.java
+++ b/tomcat-embedded-common/src/main/java/org/jboss/arquillian/container/tomcat/embedded/TomcatEmbeddedConfiguration.java
@@ -30,13 +30,13 @@ public class TomcatEmbeddedConfiguration implements ContainerConfiguration {
 
     private String bindAddress = "localhost";
 
-    private int bindHttpPort = 8080;
+    private int bindHttpPort; // CHANGED: Use 0 as default to auto select next free port (this change is not strictly necessary, it is also possible to set 0 by configuration)
 
-    private String tomcatHome = null;
+    private String tomcatHome;
 
     private String appBase = "webapps";
 
-    private String workDir = null;
+    private String workDir;
 
     private String serverName = "arquillian-tomcat-embedded";
 


### PR DESCRIPTION
#### Short description of what this resolves:
As discussed in here: https://github.com/arquillian/arquillian-container-tomcat/issues/115 here the pull request to allow automatic port selection by the arquillian tomcat plugin.

I added comments to all done changes.

#### Changes proposed in this pull request:

- allow automatic port selection by Tomcat class


**Fixes**: #

- changed final HTTPContext httpContext = new HTTPContext(configuration.getBindAddress(), configuration.getBindHttpPort()); to new HTTPContext(tomcat.getHost().getName(), tomcat.getConnector().getLocalPort()); in Tomcat8EmbeddedContainer.java so HTTPContext uses port choosen by Tomcat, and no longer set by user in configuration. This allows setting of 0 and to let tomcat choose an available port by its own.

- changed ((StandardHost) host).setUnpackWARs(configuration.isUnpackArchive()); back to embeddedHostConfig.setUnpackWARs(configuration.isUnpackArchive()); because in out arquillian setup, ((StandardHost) host).setUnpackWARs(configuration.isUnpackArchive());  will not work propably

