### PR TITLE
Re-introduce Tomcat10EmbeddedInContainerIT and changes needed for that

### DIFF
--- a/tomcat-embedded-10/pom.xml
+++ b/tomcat-embedded-10/pom.xml
@@ -15,6 +15,8 @@
 
   <properties>
     <tomcat.version>10.1.0-M16</tomcat.version>
+    <!-- Needs newer version because of deprecated method removal in CDI 4 and subsequent adjustments in Arq. -->
+    <arquillian.core.version>1.7.0.Alpha10</arquillian.core.version>
     <ecj.version>4.6.1</ecj.version>
   </properties>
 

--- a/tomcat-embedded-10/src/test/java/org/jboss/arquillian/container/tomcat/embedded/Tomcat10EmbeddedInContainerIT.java
+++ b/tomcat-embedded-10/src/test/java/org/jboss/arquillian/container/tomcat/embedded/Tomcat10EmbeddedInContainerIT.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2022, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.tomcat.embedded;
+
+import static org.jboss.arquillian.container.tomcat.test.TestDeploymentFactory.ROOT_CONTEXT;
+import static org.jboss.arquillian.container.tomcat.test.TestDeploymentFactory.SERVLET_5;
+import static org.jboss.arquillian.container.tomcat.test.TestDeploymentFactory.TEST_CONTEXT;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.tomcat.test.TomcatInContainerITBase;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that Tomcat deployments into the Tomcat server work through the Arquillian lifecycle
+ */
+@RunWith(Arquillian.class)
+public class Tomcat10EmbeddedInContainerIT extends TomcatInContainerITBase {
+
+    @Deployment(name = ROOT_CONTEXT)
+    public static WebArchive createRootDeployment() {
+
+        return TEST_DEPLOYMENT_FACTORY.createWebAppInContainerDeployment(ROOT_CONTEXT, SERVLET_5);
+    }
+
+    @Deployment(name = TEST_CONTEXT)
+    public static WebArchive createTestDeployment() {
+
+        return TEST_DEPLOYMENT_FACTORY.createWebAppInContainerDeployment(TEST_CONTEXT, SERVLET_5);
+    }
+}

--- a/tomcat-jakarta/src/test/java/org/jboss/arquillian/container/tomcat/test/TestBean.java
+++ b/tomcat-jakarta/src/test/java/org/jboss/arquillian/container/tomcat/test/TestBean.java
@@ -17,10 +17,12 @@
 package org.jboss.arquillian.container.tomcat.test;
 
 import jakarta.annotation.Resource;
+import jakarta.enterprise.context.Dependent;
 
 /**
  * @author Dan Allen
  */
+@Dependent
 public class TestBean {
 
     @Resource(name = "resourceInjectionTestName")


### PR DESCRIPTION
Fixes #89 

`<arquillian.core.version>1.7.0.Alpha10</arquillian.core.version>` version override can go away once the repo shifts to EE 10+ only.