### PR TITLE
Revert version to 1.2.0 since last release was 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.jboss.arquillian.container</groupId>
   <artifactId>arquillian-parent-tomcat</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Arquillian Tomcat Container Parent</name>

--- a/tomcat-common/pom.xml
+++ b/tomcat-common/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jboss.arquillian.container</groupId>
     <artifactId>arquillian-parent-tomcat</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>arquillian-tomcat-common</artifactId>

--- a/tomcat-container-parent/pom.xml
+++ b/tomcat-container-parent/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jboss.arquillian.container</groupId>
     <artifactId>arquillian-parent-tomcat</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>arquillian-tomcat-container-parent</artifactId>

--- a/tomcat-embedded-10/pom.xml
+++ b/tomcat-embedded-10/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jboss.arquillian.container</groupId>
     <artifactId>arquillian-tomcat-embedded-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <relativePath>../tomcat-embedded-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/tomcat-embedded-common/pom.xml
+++ b/tomcat-embedded-common/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jboss.arquillian.container</groupId>
     <artifactId>arquillian-parent-tomcat</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>arquillian-tomcat-embedded-common</artifactId>

--- a/tomcat-embedded-parent/pom.xml
+++ b/tomcat-embedded-parent/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jboss.arquillian.container</groupId>
     <artifactId>arquillian-tomcat-container-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <relativePath>../tomcat-container-parent/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
In previous PRs I mistakenly raised the version to 1.3.0 thinking the last release was 1.2.0.
I was wrong - last release was 1.1.0, so the next version (including bump), should be 1.2.0.