### PR TITLE
CI: JDK 22 is now GA; cleanup workflow definition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
-name: Arquillian Container Tomcat CI
-
+name: CI
 on:
   push:
     branches:
@@ -7,15 +6,14 @@ on:
   pull_request:
     branches:
       - '*'
-
 jobs:
   ci:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        java: [ 11, 17, 21 ]
+        # Keep this list as: all supported LTS JDKs, the latest GA JDK, and optionally the latest EA JDK (if available).
+        java: [ 11, 17, 21, 22 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,11 +29,11 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Build with Maven
-        run: mvn --batch-mode verify
-      - name: Archive Surefire Reports
+      - name: Build with Maven using JDK ${{ matrix.java }}
+        run: mvn --batch-mode --no-transfer-progress verify
+      - name: Archive Failsafe Reports
+        if: failure()
         uses: actions/upload-artifact@v4
-        if: always()
         with:
           name: ${{ runner.os }}-${{ matrix.java }}-failsafe-reports
           path: '**/target/failsafe-reports/*.xml'


### PR DESCRIPTION
JDK 22 GA is now out, add it to the test matrix

https://blogs.oracle.com/java/post/the-arrival-of-java-22