### PR TITLE
fix: fixed random port selection support

### DIFF
--- a/tomcat-embedded-10/src/main/java/org/jboss/arquillian/container/tomcat/embedded/Tomcat10EmbeddedContainer.java
+++ b/tomcat-embedded-10/src/main/java/org/jboss/arquillian/container/tomcat/embedded/Tomcat10EmbeddedContainer.java
@@ -145,8 +145,9 @@ public class Tomcat10EmbeddedContainer implements DeployableContainer<TomcatEmbe
             final StandardContext standardContext = (StandardContext) host.findChild(contextName.getName());
             standardContextProducer.set(standardContext);
 
+            // Use tomcat values instead of configuration ones to support automatic/random port selection
             final HTTPContext httpContext =
-                new HTTPContext(configuration.getBindAddress(), configuration.getBindHttpPort());
+                new HTTPContext(tomcat.getHost().getName(), tomcat.getConnector().getLocalPort());
 
             for (final String mapping : standardContext.findServletMappings()) {
                 httpContext.add(new Servlet(standardContext.findServletMapping(mapping), contextName.getPath()));
@@ -222,7 +223,7 @@ public class Tomcat10EmbeddedContainer implements DeployableContainer<TomcatEmbe
         host.setConfigClass(EmbeddedContextConfig.class.getCanonicalName());
 
         embeddedHostConfig = new EmbeddedHostConfig();
-        ((StandardHost) host).setUnpackWARs(configuration.isUnpackArchive());
+        embeddedHostConfig.setUnpackWARs(configuration.isUnpackArchive());
 
         host.addLifecycleListener(embeddedHostConfig);
 


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes the scenario with random / automatic port selection when starting the embedded Tomcat instance. Supersedes https://github.com/arquillian/arquillian-container-tomcat/pull/116

#### Changes proposed in this pull request:

- Allow using `bindHttpPort=0` in configuration


**Fixes**: #115
