### PR TITLE
Test embedded-10 container with a typical value of 0 which assigns a …

### DIFF
--- a/tomcat-embedded-10/src/test/resources/arquillian.xml
+++ b/tomcat-embedded-10/src/test/resources/arquillian.xml
@@ -6,7 +6,9 @@
     <configuration>
       <property name="tomcatHome">target/tomcat-embedded-10</property>
       <property name="workDir">work</property>
-      <property name="bindHttpPort">8888</property>
+      <!-- Test with a typical value of 0 which assigns a random port (since 1.2.2.Final). -->
+      <!-- When undefined, TomcatEmbeddedConfiguration#bindHttpPort defaults to 8080. -->
+      <property name="bindHttpPort">0</property>
       <property name="unpackArchive">true</property>
     </configuration>
   </container>


### PR DESCRIPTION
…random port.

Follow up on https://github.com/arquillian/arquillian-container-tomcat/pull/179.